### PR TITLE
Add Power ppc64le platform support

### DIFF
--- a/deps/3rd/obclient.el8.ppc64le.deps
+++ b/deps/3rd/obclient.el8.ppc64le.deps
@@ -1,0 +1,8 @@
+[target]
+os=8
+arch=ppc64le
+repo=file:///home/ips_ob/deps_ppc64le_rpm
+
+[deps]
+devdeps-openssl-static-1.1.1u-1.el8.ppc64le.rpm
+devdeps-ncurses-static-6.2-1.el8.ppc64le.rpm

--- a/deps/3rd/obclient.el8.ppc64le.deps
+++ b/deps/3rd/obclient.el8.ppc64le.deps
@@ -1,7 +1,7 @@
 [target]
 os=8
 arch=ppc64le
-repo=file:///home/ips_ob/deps_ppc64le_rpm
+repo=https://mirrors.aliyun.com/oceanbase/development-kit/el/8/ppc64le
 
 [deps]
 devdeps-openssl-static-1.1.1u-1.el8.ppc64le.rpm


### PR DESCRIPTION
Add Power ppc64le platform support, now just use local repo for deps rpm, will update later when remote repo is ready.

Create new obclient.el8.ppc64le.deps File: 
[target]
os=8
arch=ppc64le
repo=file:///home/ips_ob/deps_ppc64le_rpm

[deps]
devdeps-openssl-static-1.1.1u-1.el8.ppc64le.rpm
devdeps-ncurses-static-6.2-1.el8.ppc64le.rpm

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
